### PR TITLE
Corrected some long-form getopt option-specifiers

### DIFF
--- a/common.py
+++ b/common.py
@@ -27,8 +27,8 @@ from utils import *
 import sys, getopt
 
 COMMON_GETOPTS = "hfa:J:nN:lL:kK:tT:oO:C:sSip"
-COMMON_GETOPTS_LONG = ["help", "force", "adm1=", "set-imsi", "mnclen",
-		       "set-mnclen", "milenage", "set-milenage", "ki",
+COMMON_GETOPTS_LONG = ["help", "force", "adm1=", "set-imsi=", "mnclen",
+		       "set-mnclen=", "milenage", "set-milenage=", "ki",
 		       "set-ki=", "auth", "set-auth=", "opc", "set-op=",
 		       "set-opc=", "seq-parameters", "reset-seq-parameters"
 		       "iccid", "aid"]


### PR DESCRIPTION
The set-imsi, set-mnclen and set-milenage option specifier strings each need a trailing equals sign, otherwise the getopt.getopt() function does not parse the subsequent argument correctly.  Symptom is that 
    python3 sysmo-isim-tool.sja2.py --adm1 12345678 -J 001010000056789
works, but
    python3 sysmo-isim-tool.sja2.py --adm1 12345678 --set-imsi 001010000056789
does not (and similarly -N works but --set-mnclen does not).